### PR TITLE
Update Wrapper.svelte to remove pages

### DIFF
--- a/components/Wrapper.svelte
+++ b/components/Wrapper.svelte
@@ -31,22 +31,17 @@
 
 <nav class="navbar-top">
 	<div class="centered-content navbar-top-content">
+		<!-- Josh, can we turn the DI logo into the "Home" link and remove the words? I can't do it, but I'd prefer that for design purposes. -->
 		<img
 			src={rootPath + "images/logo-bb-white-circle.svg"}
 			alt="BB logo in white circle"
 		>
 		<ul>
 			<li>
-				<a href={rootPath}>Home</a>
+				<a href={rootPath + "contact.html"}>About</a>
 			</li>
 			<li>
-				<a href="https://donations.biblicalblueprints.org">Give</a>
-			</li>
-			<li>
-				<a href={rootPath + "contact.html"}>Contact</a>
-			</li>
-			<li>
-				<a href={rootPath + "email-list.html"}>Email list</a>
+				<a href="https://donations.biblicalblueprints.org">Support</a>
 			</li>
 		</ul>
 	</div>


### PR DESCRIPTION
- Removed Home and Email List pages. 
- Renamed Give to Support (though it might be better still as Donate) 
- Renamed Contact to About - and will modify Contact to become About in a different pull. 
- Requested that a programmer turn the new Dominion Institute logo into the "Home" link.